### PR TITLE
Remove ActiveSupport::OrderedHash

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - >
         FFMPEG_DIR="$HOME/ffmpeg_build";
-        FFMPEG_VERSION="2.6.3";
+        FFMPEG_VERSION="3.3.3";
         if [ ! -d "$FFMPEG_DIR" ]; then
         mkdir "$FFMPEG_DIR" &&
         cd "$FFMPEG_DIR" &&

--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,9 @@ dependencies:
         mkdir fdkaac &&
         mkdir src &&
         cd src &&
-        wget https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.5.tar.gz &&
-        tar xfz fdk-aac-0.1.5.tar.gz &&
-        cd fdk-aac-0.1.5 &&
+        wget https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz &&
+        tar xfz fdk-aac-0.1.4.tar.gz &&
+        cd fdk-aac-0.1.4 &&
         autoreconf -fvi &&
         ./configure --prefix="$FFMPEG_DIR/fdkaac" --disable-shared &&
         sudo make install &&

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - >
         FFMPEG_DIR="$HOME/ffmpeg_build";
-        FFMPEG_VERSION="3.3.3";
+        FFMPEG_VERSION="2.6.3";
         if [ ! -d "$FFMPEG_DIR" ]; then
         mkdir "$FFMPEG_DIR" &&
         cd "$FFMPEG_DIR" &&
@@ -15,9 +15,9 @@ dependencies:
         mkdir fdkaac &&
         mkdir src &&
         cd src &&
-        wget https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz &&
-        tar xfz fdk-aac-0.1.4.tar.gz &&
-        cd fdk-aac-0.1.4 &&
+        wget https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.5.tar.gz &&
+        tar xfz fdk-aac-0.1.5.tar.gz &&
+        cd fdk-aac-0.1.5 &&
         autoreconf -fvi &&
         ./configure --prefix="$FFMPEG_DIR/fdkaac" --disable-shared &&
         sudo make install &&

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ dependencies:
         tar -xjpf "ffmpeg-$FFMPEG_VERSION.tar.bz2" &&
         cd "ffmpeg-$FFMPEG_VERSION" &&
         ./configure
+        --disable-yasm
         --extra-cflags="-I$FFMPEG_DIR/fdkaac/include"
         --extra-ldflags="-L$FFMPEG_DIR/fdkaac/lib"
         --enable-gpl

--- a/lib/mediakit/ffmpeg/options.rb
+++ b/lib/mediakit/ffmpeg/options.rb
@@ -62,7 +62,7 @@ module Mediakit
       end
 
       # Base class for Options
-      class OrderedHash < ActiveSupport::OrderedHash
+      class OrderedHash < Hash
         # @param [Hash] options initial option values
         def initialize(options = {})
           options.each { |key, value| raise_if_invalid_arg_error(key, value) } if options

--- a/mediakit.gemspec
+++ b/mediakit.gemspec
@@ -22,7 +22,7 @@ EOS
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "cool.io", "~> 1.3"
+  spec.add_runtime_dependency "cool.io", "~> 1.5.2"
   spec.add_development_dependency "pry", '~> 0.10'
   spec.add_development_dependency "ruby-debug-ide", "~> 0.4"
   spec.add_development_dependency "yard", "> 0.8"

--- a/mediakit.gemspec
+++ b/mediakit.gemspec
@@ -22,9 +22,7 @@ EOS
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 4"
   spec.add_runtime_dependency "cool.io", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", '~> 0.10'
   spec.add_development_dependency "ruby-debug-ide", "~> 0.4"
   spec.add_development_dependency "yard", "> 0.8"


### PR DESCRIPTION
I want to use MediaKit with Rails 5.

`ActiveSupport::OrderedHash` is Deprecated.
I removed its dependencies, because it is unnecessary for MediaKit.